### PR TITLE
EUCA-7868: get rid of http default mode

### DIFF
--- a/scripts/haproxy_template.conf
+++ b/scripts/haproxy_template.conf
@@ -5,7 +5,6 @@ global
  pidfile /var/run/haproxy.pid
 
 defaults
- mode http
  contimeout      1000
  clitimeout      10000
  srvtimeout      10000


### PR DESCRIPTION
https://eucalyptus.atlassian.net/browse/EUCA-7868

Having default mode breaks tcp loadbalancing.
