### PR TITLE
Use counters instead of timestamps in load balancer servo loops

### DIFF
--- a/servo/cw_loop.py
+++ b/servo/cw_loop.py
@@ -37,10 +37,6 @@ class CWLoop(threading.Thread):
             servo.log.error('some required parameters are missing; failed to start cloudwatch report loop')
             return
 
-        start_time = time.time()
-        while time.time() - start_time < config.CWATCH_REPORT_PERIOD_SEC and self.running:
-            time.sleep(1)
-
         while self.running:
             aws_access_key_id = config.get_access_key_id()
             aws_secret_access_key = config.get_secret_access_key()
@@ -52,10 +48,11 @@ class CWLoop(threading.Thread):
                 servo.log.debug('reported the metrics: %s' % metric)
             except Exception, err:
                 servo.log.error('failed to report the cloudwatch metrics: %s', err)
- 
-            start_time = time.time()
-            while time.time() - start_time < config.CWATCH_REPORT_PERIOD_SEC and self.running:
+
+            cw_loop_delay = config.CWATCH_REPORT_PERIOD_SEC
+            while cw_loop_delay > 0 and self.running:
                 time.sleep(1)
+                cw_loop_delay -= 1
 
     def stop(self):
         self.running = False

--- a/servo/health_check.py
+++ b/servo/health_check.py
@@ -185,10 +185,11 @@ class InstanceHealthChecker(threading.Thread):
                 healthy_count = 0
             if unhealthy_count > health_check_config.unhealthy_threshold:
                 unhealthy_count = 0
-            start_time = time.time()
-            while time.time() - start_time < health_check_config.interval and self.running:
+            health_check_delay = health_check_config.interval
+            while health_check_delay > 0 and self.running:
                 time.sleep(1)
-           
+                health_check_delay -= 1
+
     def check_http(self, target):
         target = target.replace('HTTP','').replace('http','').replace('Http','').replace(':','')
         idx = target.find('/')

--- a/servo/main_loop.py
+++ b/servo/main_loop.py
@@ -120,9 +120,10 @@ class ServoLoop(object):
         
           # (future) put health check results to the elb service
           # (future) put cloudwatch metrics to the elb service
-            start_time = time.time()
-            while time.time() - start_time < config.QUERY_PERIOD_SEC and self.__status == ServoLoop.RUNNING:
+            query_period_delay = config.QUERY_PERIOD_SEC
+            while query_period_delay > 0 and self.__status == ServoLoop.RUNNING:
                 time.sleep(1)
+                query_period_delay -= 1
 
         self.__status = ServoLoop.STOPPED
 


### PR DESCRIPTION
Use counters instead of absolute time comparisons for delay loops in servo. Time comparisons will hang for extended periods if clock is moved backwards, which can happen if NTP update is performed after servo is started. Counters give good enough accuracy for the intended delay loops.
