### PR TITLE
Updated haproxy_template.conf to contain non-deprecated configuration options

### DIFF
--- a/scripts/haproxy_template.conf
+++ b/scripts/haproxy_template.conf
@@ -9,7 +9,7 @@ global
  group servo
 
 defaults
- contimeout      1000
- clitimeout      10000
- srvtimeout      10000
+ timeout connect     5s
+ timeout client      2m
+ timeout server      2m
  option http-server-close # affects KA on/off


### PR DESCRIPTION
The following options in haproxy_template.conf are deprecated per [HAProxy 1.5 Config Documentation](http://www.haproxy.org/download/1.5/doc/configuration.txt):
- srvtimeout - This parameter is provided for compatibility but is currently deprecated.
  Please use "timeout server" instead.
- clitimeout  - This parameter is provided for compatibility but is currently deprecated.
  Please use "timeout client" instead.
- contimeout - This parameter is provided for backwards compatibility but is currently
  deprecated. Please use "timeout connect", "timeout queue" or "timeout tarpit"
  instead.

These config options were replaced in this pull request accordingly, and values increased.
- srvtimeout => "timeout server"
- clitimeout => "timeout client"
- contimeout => "timeout connect"
