### PR TITLE
Added fix for https://eucalyptus.atlassian.net/browse/EUCA-9996

### DIFF
--- a/scripts/haproxy_template.conf
+++ b/scripts/haproxy_template.conf
@@ -12,4 +12,3 @@ defaults
  contimeout      1000
  clitimeout      10000
  srvtimeout      10000
- option http-server-close # affects KA on/off

--- a/servo/haproxy/haproxy_conf.py
+++ b/servo/haproxy/haproxy_conf.py
@@ -164,6 +164,8 @@ class ConfBuilderHaproxy(ConfBuilder):
                 self.__content_map[section_name].append('mode %s' % protocol)
             if protocol == 'http' or protocol == 'https':
                 self.__content_map[section_name].append('option forwardfor except 127.0.0.1')
+                self.__content_map[section_name].append('timeout http-keep-alive 50ms')
+                self.__content_map[section_name].append('timeout http-request 5s')
             if protocol == 'https' or protocol == 'ssl':
                 self.__content_map[section_name].append('bind 0.0.0.0:%s ssl crt %s' % (port, cert))
             else: 


### PR DESCRIPTION
Fix to make Connection request header return "keep-alive" value per issue communicated in https://eucalyptus.atlassian.net/browse/EUCA-9996.
